### PR TITLE
Enhance painting functionality and refactor Tool classes

### DIFF
--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -47,9 +47,12 @@ public partial class MainPage : ContentPage
     	DrawGridOverlay(canvas, e.Info.Width, e.Info.Height, _pixelSize);
     }
 
+	private bool doPaint = false;
 	private void OnCanvasViewTouch(object sender, SKTouchEventArgs e)
 	{
-		if (e.ActionType == SKTouchAction.Pressed || e.ActionType == SKTouchAction.Moved)
+		if (e.ActionType == SKTouchAction.Pressed) { doPaint = true; }
+        if (e.ActionType == SKTouchAction.Released) { doPaint = false; }
+        if (doPaint && e.ActionType == SKTouchAction.Moved)
 		{
 			var canvasView = (SKCanvasView)sender;
 

--- a/Tool.cs
+++ b/Tool.cs
@@ -1,11 +1,11 @@
 using System;
-using Android.Health.Connect.DataTypes;
+
 
 namespace PocketSprite;
 
 public class Tool
 {
-    bool isActive;
+    public bool isActive;
     public Tool(bool _isActive) {
         isActive = _isActive;
     }

--- a/ToolManager.cs
+++ b/ToolManager.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-using AndroidX.Lifecycle.ViewModels;
+
 using Microsoft.Maui.Controls.Platform;
 
 namespace PocketSprite;
@@ -9,7 +9,7 @@ public class ToolManager
 {
     public List<Tool> _toolSet = new List<Tool>();
     private Tool activeTool;
-    public ToolManager(Tool active=) {
+    public ToolManager(Tool active) {
 
     }
 
@@ -29,6 +29,6 @@ public class ToolManager
             if (tool.isActive)
                 return tool;
         }
-        return brushTool;
+        return new Tool(true);
     }
 }


### PR DESCRIPTION
Now, the mouse button has to be pressed to start painting. When released, it stops. Should work with android?

- Added `doPaint` boolean in `MainPage.xaml.cs` to manage painting state during touch events.
- Updated `isActive` field in `Tool.cs` to be public and modified the constructor for direct initialization.
- Corrected `ToolManager` constructor in `ToolManager.cs` and updated using directives for dependency changes.
- Changed `GetActiveTool` method to return a new `Tool` instance when no active tool is found.